### PR TITLE
Start reverse tethering on startup on all connected devices

### DIFF
--- a/simple-rt-cli/src/main.c
+++ b/simple-rt-cli/src/main.c
@@ -126,8 +126,9 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    rc = libusb_hotplug_register_callback(NULL, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, 0,
-            LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
+    rc = libusb_hotplug_register_callback(NULL, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED,
+            LIBUSB_HOTPLUG_ENUMERATE, LIBUSB_HOTPLUG_MATCH_ANY,
+            LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
             hotplug_callback, NULL, &callback_handle);
 
     if (rc != LIBUSB_SUCCESS) {


### PR DESCRIPTION
I changed the libusb_hotplug_flag of libusb_hotplug_register_callback
from LIBUSB_HOTPLUG_NO_FLAGS to LIBUSB_HOTPLUG_ENUMERATE. This way,
the callback is fired for all currently attached devices. Otherwise,
you would have to disconnect and reconnect again a device that is
already attached when SimpleRT is started.