### PR TITLE
Fix race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       on:
         tags: true
   - language: android
+    components:
+    - build-tools-24.0.0
+    - android-24
     before_script:
     - cd simple-rt-android
     - git clone https://github.com/urho3d/android-ndk.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ matrix:
       on:
         tags: true
   - language: android
-    components:
-    - build-tools-24.0.0
-    - android-24
+    android:
+      components:
+      - build-tools-24.0.0
+      - android-24
     before_script:
     - cd simple-rt-android
     - git clone https://github.com/urho3d/android-ndk.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+matrix:
+  include:
+  - language: C
+    before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq build-essential pkg-config libusb-1.0-0-dev
+    before_script: cd simple-rt-cli
+    script: make
+  - language: android
+    before_script:
+    - cd simple-rt-android
+    - git clone https://github.com/urho3d/android-ndk.git
+    - printf "ndk.dir=$(pwd)/android-ndk\nsdk.dir=/usr/local/android-sdk\n" > local.properties
+    script: "./gradlew assembleDebug"
+deploy:
+  provider: releases
+  api_key:
+    secure: WIFj8QBhguQb55USl7TFuRIkzbTF8AjWT5KdiE7HnIFbb5ICzCgwfPH7vZKw8tXhmVtsEQpuf3GMea7E7VdBksHDrSPPBoW2HWGq5uk7Lz8B5GYw2gkYBgXtZtatTtG0DS8Ae1nbmY7TbIcj1+/4Fj4oTGkmACUYYYeOo7ThZwJHKkVwkQF5GU8LJ18JHavob3ndWGJeT/aawpja+kgb/820r1ggIAJNJqxqz8fFRde2ed+IXCLLIOinSemRjy3OSqnRzJta7n3v4QHzX5QbuyQIHJl0VS3vpmehgUSiv1pGl5pFLRqVcVPN72jNcCocHl9jKi1DNhCxm2OkJgN0ac6HSLvUiMl1S/BtCbdsEjg52H0rkZNQtDOuBpol/Bf5QAw0zZrW1F99rFVw4PPMu3noxi3VJvP/gHugutJONkBuaatO+LZD9A462rnDf6X2mlUzJxsy8I3ysd+zQ7kJK6mLqmq9lRvAJSwPu0+v3eff5Qs/mv1Hn2fpFZZdHN08MnHGMrCxBs3FGu72ihBDVvrrtAZAm63N/bLxe3GXcEKBowOOGRpvGl5+jFt+E4yQAsZcsEKtE6G9kM0jmcySO+PPic1lzW4sZg7do92/lcRAQtPfFkvIk1ZD/GF01qddOBH0xafiC4lYwfHdFe3GKeH4RBo+sHryQO9xroDAFWU=
+  file: simple-rt-cli/simple-rt
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,25 @@ matrix:
     - sudo apt-get install -qq build-essential pkg-config libusb-1.0-0-dev
     before_script: cd simple-rt-cli
     script: make
+    deploy:
+      provider: releases
+      api_key:
+        secure: WIFj8QBhguQb55USl7TFuRIkzbTF8AjWT5KdiE7HnIFbb5ICzCgwfPH7vZKw8tXhmVtsEQpuf3GMea7E7VdBksHDrSPPBoW2HWGq5uk7Lz8B5GYw2gkYBgXtZtatTtG0DS8Ae1nbmY7TbIcj1+/4Fj4oTGkmACUYYYeOo7ThZwJHKkVwkQF5GU8LJ18JHavob3ndWGJeT/aawpja+kgb/820r1ggIAJNJqxqz8fFRde2ed+IXCLLIOinSemRjy3OSqnRzJta7n3v4QHzX5QbuyQIHJl0VS3vpmehgUSiv1pGl5pFLRqVcVPN72jNcCocHl9jKi1DNhCxm2OkJgN0ac6HSLvUiMl1S/BtCbdsEjg52H0rkZNQtDOuBpol/Bf5QAw0zZrW1F99rFVw4PPMu3noxi3VJvP/gHugutJONkBuaatO+LZD9A462rnDf6X2mlUzJxsy8I3ysd+zQ7kJK6mLqmq9lRvAJSwPu0+v3eff5Qs/mv1Hn2fpFZZdHN08MnHGMrCxBs3FGu72ihBDVvrrtAZAm63N/bLxe3GXcEKBowOOGRpvGl5+jFt+E4yQAsZcsEKtE6G9kM0jmcySO+PPic1lzW4sZg7do92/lcRAQtPfFkvIk1ZD/GF01qddOBH0xafiC4lYwfHdFe3GKeH4RBo+sHryQO9xroDAFWU=
+      file: simple-rt
+      skip_cleanup: true
+      on:
+        tags: true
   - language: android
     before_script:
     - cd simple-rt-android
     - git clone https://github.com/urho3d/android-ndk.git
     - printf "ndk.dir=$(pwd)/android-ndk\nsdk.dir=/usr/local/android-sdk\n" > local.properties
     script: "./gradlew assembleDebug"
-deploy:
-  provider: releases
-  api_key:
-    secure: WIFj8QBhguQb55USl7TFuRIkzbTF8AjWT5KdiE7HnIFbb5ICzCgwfPH7vZKw8tXhmVtsEQpuf3GMea7E7VdBksHDrSPPBoW2HWGq5uk7Lz8B5GYw2gkYBgXtZtatTtG0DS8Ae1nbmY7TbIcj1+/4Fj4oTGkmACUYYYeOo7ThZwJHKkVwkQF5GU8LJ18JHavob3ndWGJeT/aawpja+kgb/820r1ggIAJNJqxqz8fFRde2ed+IXCLLIOinSemRjy3OSqnRzJta7n3v4QHzX5QbuyQIHJl0VS3vpmehgUSiv1pGl5pFLRqVcVPN72jNcCocHl9jKi1DNhCxm2OkJgN0ac6HSLvUiMl1S/BtCbdsEjg52H0rkZNQtDOuBpol/Bf5QAw0zZrW1F99rFVw4PPMu3noxi3VJvP/gHugutJONkBuaatO+LZD9A462rnDf6X2mlUzJxsy8I3ysd+zQ7kJK6mLqmq9lRvAJSwPu0+v3eff5Qs/mv1Hn2fpFZZdHN08MnHGMrCxBs3FGu72ihBDVvrrtAZAm63N/bLxe3GXcEKBowOOGRpvGl5+jFt+E4yQAsZcsEKtE6G9kM0jmcySO+PPic1lzW4sZg7do92/lcRAQtPfFkvIk1ZD/GF01qddOBH0xafiC4lYwfHdFe3GKeH4RBo+sHryQO9xroDAFWU=
-  file: simple-rt-cli/simple-rt
-  skip_cleanup: true
-  on:
-    tags: true
+    deploy:
+      provider: releases
+      api_key:
+        secure: WIFj8QBhguQb55USl7TFuRIkzbTF8AjWT5KdiE7HnIFbb5ICzCgwfPH7vZKw8tXhmVtsEQpuf3GMea7E7VdBksHDrSPPBoW2HWGq5uk7Lz8B5GYw2gkYBgXtZtatTtG0DS8Ae1nbmY7TbIcj1+/4Fj4oTGkmACUYYYeOo7ThZwJHKkVwkQF5GU8LJ18JHavob3ndWGJeT/aawpja+kgb/820r1ggIAJNJqxqz8fFRde2ed+IXCLLIOinSemRjy3OSqnRzJta7n3v4QHzX5QbuyQIHJl0VS3vpmehgUSiv1pGl5pFLRqVcVPN72jNcCocHl9jKi1DNhCxm2OkJgN0ac6HSLvUiMl1S/BtCbdsEjg52H0rkZNQtDOuBpol/Bf5QAw0zZrW1F99rFVw4PPMu3noxi3VJvP/gHugutJONkBuaatO+LZD9A462rnDf6X2mlUzJxsy8I3ysd+zQ7kJK6mLqmq9lRvAJSwPu0+v3eff5Qs/mv1Hn2fpFZZdHN08MnHGMrCxBs3FGu72ihBDVvrrtAZAm63N/bLxe3GXcEKBowOOGRpvGl5+jFt+E4yQAsZcsEKtE6G9kM0jmcySO+PPic1lzW4sZg7do92/lcRAQtPfFkvIk1ZD/GF01qddOBH0xafiC4lYwfHdFe3GKeH4RBo+sHryQO9xroDAFWU=
+      file: app/build/outputs/apk/app-debug.apk
+      skip_cleanup: true
+      on:
+        tags: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Development is still in progress, bugs and errors can occur.
 ```
 IMPORTANT!
    If you have any issues with this tool, please, provide some logs:
-   - run util in debug mode (-d), connect you device
+   - run util in debug mode (-d), connect your device
    - run "ip addr show"
    - run "ip route show"
    - store this output into issue ticket on github
@@ -39,7 +39,7 @@ The SimpleRT utility consists of 2 parts:
    - Android 4.0 and higher.
 
    Build system based on gradle + gradle experimental android plugin (supporting ndk). For build you need both sdk & ndk.
-Create local.properties file in root dir, it should be looks like that:
+Create local.properties file in root dir, it should be looking like that:
    ```
    ndk.dir=/home/viper/Android/Sdk/ndk-bundle
    sdk.dir=/home/viper/Android/Sdk
@@ -50,7 +50,7 @@ Create local.properties file in root dir, it should be looks like that:
    ```
    app/build/outputs/apk/app-debug.apk is your apk.
 
-   #### There is already built [apk](https://github.com/vvviperrr/SimpleRT/releases/download/1.1/simple-rt-1.1.apk.zip)
+   #### There is an already built [apk](https://github.com/vvviperrr/SimpleRT/releases/download/1.1/simple-rt-1.1.apk.zip)
    
    <!---
    ## Now available in [f-droid](https://f-droid.org/repository/browse/?fdfilter=simplert&fdid=com.viper.simplert)
@@ -60,7 +60,7 @@ Create local.properties file in root dir, it should be looks like that:
 
    Dependencies:
    - libusb-1.0
-   - libresolv (usually already presented in both linux and macos)
+   - libresolv (usually already present in both linux and macos)
    - tuntap kernel module (linux version), utun (macos version, builtin)
    
    before build (debian based example):
@@ -85,7 +85,7 @@ First connection requires some trivial steps:
 
 Issues: Some apps do not recognize the reverse tethered internet connection due to ConnectivityManager policy. Just leave WiFi or 3g connection active, connection will go through SimpleRT anyway.
 
-Partially used code from [linux-adk](https://github.com/gibsson/linux-adk), which is licensed under the GNU GPLv2 or later. This project is under the GNU GPLv3 or later, which is compatible with the license of linux-adk.
+Partially uses code from [linux-adk](https://github.com/gibsson/linux-adk), which is licensed under the GNU GPLv2 or later. This project is under the GNU GPLv3 or later, which is compatible with the license of linux-adk.
 
 ##### License: GNU GPL v3
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ Create local.properties file in root dir, it should be looking like that:
    ```
    app/build/outputs/apk/app-debug.apk is your apk.
 
-   #### There is an already built [apk](https://github.com/vvviperrr/SimpleRT/releases/download/1.1/simple-rt-1.1.apk.zip)
-   
-   <!---
-   ## Now available in [f-droid](https://f-droid.org/repository/browse/?fdfilter=simplert&fdid=com.viper.simplert)
-   --->
-
 - Desktop part:
 
    Dependencies:

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ Create local.properties file in root dir, it should be looking like that:
    ```
    app/build/outputs/apk/app-debug.apk is your apk.
 
+   A prebuilt apk can also be found under `Downloads` at the [Github releases](https://github.com/iteratec/SimpleRT/releases)
+   tab.
+
 - Desktop part:
 
    Dependencies:
    - libusb-1.0
    - libresolv (usually already present in both linux and macos)
    - tuntap kernel module (linux version), utun (macos version, builtin)
-   
+
    before build (debian based example):
    ```
    sudo apt-get install build-essential pkg-config libusb-1.0-0-dev

--- a/simple-rt-android/build.gradle
+++ b/simple-rt-android/build.gradle
@@ -3,6 +3,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
     dependencies {
 //        classpath 'com.android.tools.build:gradle:2.1.2'
@@ -16,6 +19,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/simple-rt-cli/src/accessory.c
+++ b/simple-rt-cli/src/accessory.c
@@ -188,7 +188,6 @@ void free_accessory(accessory_t *acc)
 
     if (acc->handle) {
         printf("Closing accessory device\n");
-        libusb_release_interface(acc->handle, 0);
         libusb_close(acc->handle);
     }
 

--- a/simple-rt-cli/src/adk.c
+++ b/simple-rt-cli/src/adk.c
@@ -201,7 +201,7 @@ accessory_t *probe_usb_device(struct libusb_device *dev,
     }
 
     if (!aoa_version) {
-        fprintf(stderr, "Device is not support accessory!\n");
+        fprintf(stderr, "Detected usb device does not support Android Open Accessory protocol.\n");
         ret = 0;
         goto error;
     }

--- a/simple-rt-cli/src/adk.c
+++ b/simple-rt-cli/src/adk.c
@@ -55,8 +55,6 @@
 #define AOA_ACCESSORY_EP_IN         0x81
 #define AOA_ACCESSORY_EP_OUT        0x02
 
-#define AOA_ACCESSORY_INTERFACE     0x00
-
 /* ACC params */
 #define ACC_TIMEOUT 200
 
@@ -80,7 +78,7 @@ static uint16_t get_accessory_endpoints(struct libusb_device *dev)
     }
 
     /* FIXME: get interface by name? */
-    const struct libusb_interface *iface = &config->interface[AOA_ACCESSORY_INTERFACE];
+    const struct libusb_interface *iface = config->interface;
 
     if (!iface) {
         goto end;
@@ -150,7 +148,6 @@ accessory_t *probe_usb_device(struct libusb_device *dev,
         gen_new_serial_str_cb gen_new_serial_str)
 {
     int ret = 0;
-    int is_detached = 0;
     uint16_t aoa_version = 0;
     char serial_str[128] = { 0 };
 
@@ -165,30 +162,8 @@ accessory_t *probe_usb_device(struct libusb_device *dev,
     if (is_accessory_present(dev)) {
         uint16_t endpoints = get_accessory_endpoints(dev);
 
-        /* Claiming first (accessory) interface from usb device */
-        ret = libusb_claim_interface(handle, AOA_ACCESSORY_INTERFACE);
-        if (ret != 0) {
-            fprintf(stderr, "Error claiming interface: %s\n", libusb_strerror(ret));
-            goto error;
-        }
-
         /* create accessory struct */
         return new_accessory(handle, endpoints >> 8, endpoints & 0xff);
-    }
-
-    /* Check whether a kernel driver is attached. If so, we'll need to detach it. */
-    if (libusb_kernel_driver_active(handle, AOA_ACCESSORY_INTERFACE)) {
-        puts("Kernel driver is active!");
-        ret = libusb_detach_kernel_driver(handle, AOA_ACCESSORY_INTERFACE);
-        if (ret == 0) {
-            is_detached = 1;
-            puts("Kernel driver detached!");
-        } else {
-            fprintf(stderr, "Error detaching kernel driver: %s\n", libusb_strerror(ret));
-            goto error;
-        }
-    } else {
-        puts("Kernel driver is not active!");
     }
 
     /* Now asking if device supports Android Open Accessory protocol */
@@ -299,10 +274,6 @@ accessory_t *probe_usb_device(struct libusb_device *dev,
 error:
     if (ret < 0) {
         fprintf(stderr, "Accessory init failed: %s\n", libusb_strerror(ret));
-    }
-
-    if (is_detached) {
-        libusb_attach_kernel_driver(handle, AOA_ACCESSORY_INTERFACE);
     }
 
     if (handle) {

--- a/simple-rt-cli/src/adk.c
+++ b/simple-rt-cli/src/adk.c
@@ -257,6 +257,9 @@ accessory_t *probe_usb_device(struct libusb_device *dev,
         { NULL, 0, 0, 0, 0, NULL, 0 },
     };
 
+    printf("Waiting 10 seconds before sending information to device\n");
+    sleep(10);
+
     printf("Sending identification to the device\n");
     for (struct acc_control_params_t *acp = acc_control_params;
             acp->str != NULL; acp++)


### PR DESCRIPTION
I fear that I triggered a race condition with my last pull request. The race condition is because of multiple attached usb_devices that are trying to be configured in multiple threads concurrently. These threads are detaching a kernel driver while it is already in use by a different thread. That's why configuring a device might fail in the process. 

It is my understanding that this pull request solves this problem. And the output of simple-rt is also much cleaner when simple-rt is started with an android device attached. I am explaining this pull request further in my commit message of commit 6247b70. If you would test this pull request in your setup, Eugene, you would do me a big favor. And thank you for merging my previous pull request.